### PR TITLE
Add `multiline_literal_brackets` Rule

### DIFF
--- a/iOS/.swiftlint.default.yml
+++ b/iOS/.swiftlint.default.yml
@@ -39,6 +39,7 @@ opt_in_rules:
   - identical_operands
   - collection_alignment
   - static_operator
+  - multiline_literal_brackets
 
 # Exclude pods and vendor sources
 excluded:


### PR DESCRIPTION
# Example of the rule
before:

```swift
let params = ["version": "1.0",
              "platform": "iOS"]
```

after:

```swift
let params = [
   "version": "1.0",
   "platform": "iOS"
]
```